### PR TITLE
Fix bug in Total Contributions count

### DIFF
--- a/client/templates/view_data/view_data.js
+++ b/client/templates/view_data/view_data.js
@@ -84,7 +84,7 @@ Template.viewData.events({
     demData = makeDemGraphs(envId, dParams);
     groupCData = makeContributionGraphs(obsIds, dParams, sParams);
 
-    classStats(envId, sParams, obsIds, dParams);
+    classStats(envId, sParams, obsIds);
 
     makeRatioGraphs(envId, groupCData, demData);
     makeIndividualGraphs(obsIds);
@@ -314,15 +314,14 @@ function classStats(envId, sParams, obsId) {
   var conts = Sequences.find({'envId': envId}).fetch();
   var totalStuds = studs.length;
   var studTrack = new Set();
-  var totalCont = conts.length;
+  var totalCont = conts.filter(function(contribution) {
+    return obsId.includes(contribution.obsId);
+  }).length;
   var stats = $('.class-stats');
 
+
   var filteredResults = conts.filter(function(result) {
-      for (var i = 0; i < obsId.length; i++ ) {
-        if (obsId[i] === result.obsId) {
-          return result;
-        }
-      }
+    return obsId.includes(result.obsId);
   });
 
   var classRoomSummary = $('<div/>', {


### PR DESCRIPTION
Previously, the Total Contributions count was taking into account all of the observations made in an environment (regardless of what was filtered).

I also did some code cleanup and used [Array.find](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find). Let me know if this makes sense.